### PR TITLE
build: add EncoderDecoderTogether.(min|src).js to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,14 @@
 	"main": "NodeJS/EncoderAndDecoderNodeJS.min.js",
 	"module": "NodeJS/EncoderAndDecoderNodeJS.min.module.js",
 	"es2015": "NodeJS/EncoderAndDecoderNodeJS.min.module.js",
+	"browser": "EncoderDecoderTogether.min.js",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/anonyco/FastestSmallestTextEncoderDecoder.git"
 	},
 	"files": [
+		"EncoderDecoderTogether.min.js",
+		"EncoderDecoderTogether.src.js",
 		"NodeJS/EncoderAndDecoderNodeJS.min.js",
 		"NodeJS/EncoderAndDecoderNodeJS.min.js.map",
 		"NodeJS/EncoderAndDecoderNodeJS.min.module.js",


### PR DESCRIPTION
Hi @anonyco!

This updates the package.json to include the `EncoderDecoderTogether.min.js` and `EncoderDecoderTogether.src.js` files so that they are included in the publishes package, and points the `browser` key to the `EncoderDecoderTogether.min.js` file - this allows bundlers which produce a browser compatible version to consume that file.

The `EncoderDecoderTogether.min.js` was added in #1 but seems to have been dropped in 329cc5e0e2a45eca33bcb53a963a208db21922d6, I guess this was a mistake?